### PR TITLE
Add catenation result to topology

### DIFF
--- a/CoREMOF/calculation/juliapkg.json
+++ b/CoREMOF/calculation/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "CrystalNets": {
             "uuid": "7952bbbe-a946-4118-bea0-081a0932faa9",
-            "version": "0.5"
+            "version": "1.0"
         }
     }
 }


### PR DESCRIPTION
Here is a small extension of the current "topology" function to add the missing catenation result.

The function is also slightly more efficient because it will only compute the topology for the required clustering.
